### PR TITLE
Edit metadata image

### DIFF
--- a/src/components/imageDetail/ImageMetadata.vue
+++ b/src/components/imageDetail/ImageMetadata.vue
@@ -1,6 +1,12 @@
 <template>
   <div>
-    <h1 class="h1 mb-4">{{ props.image?.title || "Carregando..." }}</h1>
+    <div class="d-flex align-items-start justify-content-between mb-4">
+      <h1 class="h1 mb-4">{{ props.image?.title || "Carregando..." }}</h1>
+      <button v-if="canEdit" type="button" class="btn edit-btn" title="Editar informações"
+        aria-label="Editar informações da imagem" @click="enterEditMode">
+        <i class="bi bi-pencil-square" aria-hidden="true"></i>
+      </button>
+    </div>
 
     <div v-if="displayName" class="metadata-section">
       <h2 class="h5 metadata-title">Imagem enviada por</h2>
@@ -8,24 +14,13 @@
         <div v-if="displayAvatar" class="metadata-person-avatar">
           <img :src="displayAvatar" :alt="`Foto de ${displayName}`" />
         </div>
-        <div
-          v-else
-          class="metadata-person-avatar metadata-person-avatar--placeholder"
-        >
+        <div v-else class="metadata-person-avatar metadata-person-avatar--placeholder">
           <span>{{ displayInitial }}</span>
         </div>
-        <RouterLink
-          v-if="collectiveId"
-          :to="`/collective/${collectiveId}`"
-          class="metadata-uploader-link"
-        >
+        <RouterLink v-if="collectiveId" :to="`/collective/${collectiveId}`" class="metadata-uploader-link">
           {{ displayName }}
         </RouterLink>
-        <RouterLink
-          v-else-if="uploaderUserId"
-          :to="`/profile/${uploaderUserId}`"
-          class="metadata-uploader-link"
-        >
+        <RouterLink v-else-if="uploaderUserId" :to="`/profile/${uploaderUserId}`" class="metadata-uploader-link">
           {{ displayName }}
         </RouterLink>
         <p v-else class="metadata-text">{{ displayName }}</p>
@@ -54,13 +49,8 @@
     <div v-if="props.image?.subjects?.length" class="metadata-section">
       <h2 class="h5 metadata-title">Tags da imagem</h2>
       <div class="metadata-tags">
-        <button
-          v-for="subject in props.image.subjects"
-          :key="subject.id"
-          type="button"
-          class="btn btn-outline-primary btn-sm btn-tag"
-          @click="searchBySubject(subject)"
-        >
+        <button v-for="subject in props.image.subjects" :key="subject.id" type="button"
+          class="btn btn-outline-primary btn-sm btn-tag" @click="searchBySubject(subject)">
           {{ subject.term }}
         </button>
       </div>
@@ -69,13 +59,8 @@
     <div class="metadata-section" v-if="showMap">
       <h2 class="h5 metadata-title">Localização</h2>
       <div class="metadata-map">
-        <MapLibreMap
-          :style-url="mapStyleUrl"
-          :center="resolvedMapCenter"
-          :zoom="mapZoom"
-          :marker-position="markerPosition"
-          marker-color="#0F89E1"
-        />
+        <MapLibreMap :style-url="mapStyleUrl" :center="resolvedMapCenter" :zoom="mapZoom"
+          :marker-position="markerPosition" marker-color="#0F89E1" />
       </div>
     </div>
 
@@ -89,6 +74,12 @@ import { RouterLink, useRoute, useRouter } from "vue-router";
 import MapLibreMap from "@/components/map/MapLibreMap.vue";
 import LicenseInfoBlock from "@/components/imageDetail/LicenseInfoBlock.vue";
 import { DEFAULT_VIEW_ROUTE } from "@/constants/viewModes";
+import { useAuthStore } from "@/store/auth";
+import { storeToRefs } from "pinia";
+
+
+const authStore = useAuthStore();
+const { loggedUser } = storeToRefs(authStore);
 
 const route = useRoute();
 const router = useRouter();
@@ -104,6 +95,25 @@ const props = defineProps({
     default: null,
   },
 });
+
+const isOwner = computed(() => {
+  return loggedUser.value?.id === props.image?.uploader?.id;
+});
+
+const isEditing = computed(() => route.query.edit === "true");
+
+const canEdit = computed(() => {
+  return isOwner.value && !isEditing.value;
+});
+
+function enterEditMode() {
+  router.push({
+    query: {
+      ...route.query,
+      edit: "true",
+    },
+  });
+}
 
 function searchBySubject(subject) {
   const rawSubjects = route.query['subject[]'];
@@ -148,6 +158,9 @@ const mapCenter = computed(() => {
 
   const [lat, lng] = coordinates;
   if (typeof lat !== "number" || typeof lng !== "number") {
+    return null;
+  }
+  if (isNaN(lat) || isNaN(lng)) {
     return null;
   }
 
@@ -246,5 +259,33 @@ const markerPosition = computed(() => {
   overflow: hidden;
   background-color: #f1f3f5;
   margin-bottom: 36px;
+}
+
+.edit-btn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  background-color: var(--Laranja_E);
+  color: #fff;
+  border: none;
+  transition: background-color 0.18s ease, transform 0.12s ease, box-shadow 0.18s ease;
+
+  .bi {
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  &:hover {
+    background-color: color-mix(in srgb, var(--Laranja_M, #e05f2f) 85%, #000);
+    color: #fff;
+  }
+
+  &:focus-visible {
+    outline: none;
+  }
 }
 </style>

--- a/src/components/imageDetail/ImageMetadataEdit.vue
+++ b/src/components/imageDetail/ImageMetadataEdit.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container py-4 position-relative">
+  <div class="container px-0 py-4 position-relative">
     <transition name="fade">
       <div class="upload-box__alert" v-if="showAlert">
         <div class="alert h-auto fs-6 border border-start-3" :class="alertType === 'success'
@@ -98,12 +98,14 @@
             </div>
 
             <div class="mb-4 px-3">
-              <div class="d-flex justify-content-between align-items-center mb-2">
+              <div class="term-text-wrapper ">
+                <!-- <div class="d-flex justify-content-between align-items-center mb-2 md:flex-row flex-column gap-2"> -->
                 <h3 class="form-label text-cinza-e h3 mb-0">
                   Autorizações para publicação
                 </h3>
-                <a href="#" class="text-decoration-none d-flex align-items-center gap-1 text-muted small">
-                  <i class="bi bi-book" /> Revisar Termos e Condições
+                <!-- <a href="#" class="text-decoration-none d-flex align-items-center gap-1 text-muted text-xs"> -->
+                <a href="#" class="term-text-link text-decoration-none d-flex align-items-center gap-1 text-muted">
+                  <i class="bi bi-book" />Revisar Termos e Condições
                 </a>
               </div>
 
@@ -124,7 +126,7 @@
                       v-model="form.isPublicDomain" />
                   </div>
                 </div>
-                <div v-if="form.isPublicDomain" class="alert alert-info py-2 px-3 small mt-2">
+                <div v-if="form.isPublicDomain" class="alert alert-info py-2 px-3 small mt-2 h-auto">
                   <i class="bi bi-info-circle me-1" />
                   Mesmo em domínio público, informe o nome do autor original se souber.
                 </div>
@@ -382,7 +384,7 @@ const buildPayload = async () => {
     title: form.value.title || null,
     description: form.value.description || null,
     photographer: photographerUuid || null,
-    subjects: subjectUuids.length ? subjectUuids : null,
+    subjects: subjectUuids.length ? subjectUuids : [],
     latitude: form.value.coordinates?.lat
       ? parseFloat(form.value.coordinates.lat.toFixed(8))
       : null,
@@ -534,6 +536,29 @@ $breakpoint-md: 768px;
   }
 }
 
+.term-text-wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+
+  @media (max-width: 1024px) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .term-text-link {
+    font-size: 0.75rem;
+    margin-bottom: 20px;
+
+    .bi {
+      font-size: 14px;
+    }
+  }
+
+
+}
+
 .upload-box__alert {
   position: fixed;
   top: 20px;
@@ -561,6 +586,18 @@ $breakpoint-md: 768px;
 .fade-enter-to,
 .fade-leave-from {
   opacity: 1;
+}
+
+@media (max-width: 768px) {
+  label.form-check-label {
+    font-size: 0.75rem;
+  }
+}
+
+.form-check {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .form-check-input[role="switch"]:checked {
@@ -604,7 +641,6 @@ $breakpoint-md: 768px;
 
   .d-flex.gap-3 {
     width: 100%;
-    justify-content: flex-end;
 
     .btn {
       flex: 1;

--- a/src/components/imageDetail/ImageMetadataEdit.vue
+++ b/src/components/imageDetail/ImageMetadataEdit.vue
@@ -20,320 +20,329 @@
     </transition>
 
     <div class="row align-items-start gy-4 metadata-upload__layout">
+      <div
+        class="d-flex flex-column flex-md-row justify-content-start align-items-start align-items-md-center gap-3 bg-white py-2">
+        <ul class="nav nav-underline">
+          <li v-for="tab in tabs" :key="tab.section" class="nav-item">
+            <a class="nav-link" :href="`#${tab.section}`" :class="{ active: currentSection === tab.section }"
+              @click="selectTab(tab.section)">
+              {{ tab.label }}
+            </a>
+          </li>
+        </ul>
+      </div>
 
-      <!-- Formulário (lado direito) -->
-      <div>
-        <div
-          class="d-flex flex-column flex-md-row justify-content-start align-items-start align-items-md-center gap-3 bg-white py-2">
-          <ul class="nav nav-underline">
-            <li v-for="tab in tabs" :key="tab.section" class="nav-item">
-              <a class="nav-link" :href="`#${tab.section}`" :class="{ active: currentSection === tab.section }"
-                @click="selectTab(tab.section)">
-                {{ tab.label }}
-              </a>
-            </li>
-          </ul>
+      <div v-if="loadingImage" class="d-flex flex-column gap-4 mt-3">
+        <div class="bg-off-white p-4 rounded shadow-sm">
+          <div class="skeleton mb-3" style="height: 20px; width: 40%" />
+          <div class="skeleton mb-2" style="height: 40px; width: 100%" />
+          <div class="skeleton" style="height: 40px; width: 100%" />
+        </div>
+        <div class="bg-off-white p-4 rounded shadow-sm">
+          <div class="skeleton mb-3" style="height: 20px; width: 30%" />
+          <div class="skeleton mb-2" style="height: 40px; width: 100%" />
+          <div class="skeleton mb-2" style="height: 80px; width: 100%" />
+          <div class="skeleton" style="height: 40px; width: 60%" />
+        </div>
+      </div>
+
+      <div class="metadata-sections" v-else>
+        <!-- Publicando como -->
+        <div class="bg-off-white p-2 mb-4" style="border-radius: 5px">
+          <h2 class="text-muted fst-italic small mb-2">
+            Você está editando como
+          </h2>
+          <div>
+            <div class="d-flex align-items-center p-2" :class="{
+              'justify-content-between cursor-pointer rounded': hasCollectives,
+            }" @click="hasCollectives ? toggleIdentityDropdown() : null" :role="hasCollectives ? 'button' : undefined">
+              <div class="d-flex align-items-center gap-2" v-if="selectedIdentity">
+                <div v-if="selectedIdentity.avatar" class="rounded-circle overflow-hidden"
+                  style="width: 40px; height: 40px">
+                  <img :src="selectedIdentity.avatar" alt="" class="w-100 h-100 object-fit-cover" />
+                </div>
+                <div v-else
+                  class="rounded-circle bg-black text-white d-flex align-items-center justify-content-center fw-bold"
+                  style="width: 40px; height: 40px">
+                  {{ selectedIdentity.initials }}
+                </div>
+                <span class="fw-medium">{{ selectedIdentity.name }}</span>
+              </div>
+              <div v-else>Carregando...</div>
+              <i v-if="hasCollectives" class="bi bi-chevron-down transition-transform"
+                :class="{ 'rotate-180': isIdentityDropdownOpen }" />
+            </div>
+
+            <div v-if="hasCollectives && isIdentityDropdownOpen" class="w-100 bg-off-white rounded mt-1">
+              <div v-for="identity in availableIdentities" :key="identity.id"
+                class="d-flex align-items-center gap-2 p-2 hover-bg-light cursor-pointer identity-item"
+                @click="selectIdentity(identity)" role="button">
+                <div v-if="identity.avatar" class="rounded-circle overflow-hidden" style="width: 40px; height: 40px">
+                  <img :src="identity.avatar" alt="" class="w-100 h-100 object-fit-cover" />
+                </div>
+                <div v-else
+                  class="rounded-circle bg-black text-white d-flex align-items-center justify-content-center fw-bold"
+                  style="width: 40px; height: 40px">
+                  {{ identity.initials }}
+                </div>
+                <span class="fw-medium">{{ identity.name }}</span>
+              </div>
+            </div>
+          </div>
         </div>
 
-        <div class="metadata-sections">
-          <!-- Publicando como -->
-          <div class="bg-off-white p-2 mb-4" style="border-radius: 5px">
-            <h2 class="text-muted fst-italic small mb-2">
-              Você está editando como
-            </h2>
-            <div>
-              <div class="d-flex align-items-center p-2" :class="{
-                'justify-content-between cursor-pointer rounded': hasCollectives,
-              }" @click="hasCollectives ? toggleIdentityDropdown() : null"
-                :role="hasCollectives ? 'button' : undefined">
-                <div class="d-flex align-items-center gap-2" v-if="selectedIdentity">
-                  <div v-if="selectedIdentity.avatar" class="rounded-circle overflow-hidden"
-                    style="width: 40px; height: 40px">
-                    <img :src="selectedIdentity.avatar" alt="" class="w-100 h-100 object-fit-cover" />
-                  </div>
-                  <div v-else
-                    class="rounded-circle bg-black text-white d-flex align-items-center justify-content-center fw-bold"
-                    style="width: 40px; height: 40px">
-                    {{ selectedIdentity.initials }}
-                  </div>
-                  <span class="fw-medium">{{ selectedIdentity.name }}</span>
+        <!-- Seção: Dados Essenciais -->
+        <section id="essenciais" class="py-4 p-4 shadow-sm"
+          :class="[isEssenciaisInvalid ? 'bg-negativo-c' : 'bg-off-white']" style="border-radius: 5px">
+          <h2 class="mb-4">Dados essenciais</h2>
+
+          <div class="mb-4 px-3">
+            <UiField label="Título da imagem" explain="Adicione um título para a imagem" :invalid="isTitleInvalid"
+              invalidMessage="O título da imagem é obrigatório">
+              <template #default="{ id, ariaInvalid, ariaDescribedby }">
+                <input :id="id" type="text" class="form-control" :class="{ 'is-invalid': isTitleInvalid }"
+                  placeholder="Adicione um título" v-model="form.title" :aria-invalid="ariaInvalid"
+                  :aria-describedby="ariaDescribedby" @blur="isTitleTouched = true" />
+              </template>
+            </UiField>
+          </div>
+
+          <div class="mb-4 px-3">
+            <div class="term-text-wrapper ">
+              <!-- <div class="d-flex justify-content-between align-items-center mb-2 md:flex-row flex-column gap-2"> -->
+              <h3 class="form-label text-cinza-e h3 mb-0">
+                Autorizações para publicação
+              </h3>
+              <!-- <a href="#" class="text-decoration-none d-flex align-items-center gap-1 text-muted text-xs"> -->
+              <a href="#" class="term-text-link text-decoration-none d-flex align-items-center gap-1 text-muted">
+                <i class="bi bi-book" />Revisar Termos e Condições
+              </a>
+            </div>
+
+            <div class="d-flex justify-content-between align-items-center mb-3">
+              <label class="form-check-label text-muted fst-italic small" for="isAuthor">Sou o autor da imagem</label>
+              <div class="form-check form-switch p-0 m-0">
+                <input class="form-check-input m-0" type="checkbox" role="switch" id="isAuthor"
+                  v-model="form.isAuthor" />
+              </div>
+            </div>
+
+            <template v-if="!form.isAuthor">
+              <div class="d-flex justify-content-between align-items-center mb-3">
+                <label class="form-check-label text-muted fst-italic small" for="isPublicDomain">Imagem está em
+                  Domínio Público</label>
+                <div class="form-check form-switch p-0 m-0">
+                  <input class="form-check-input m-0" type="checkbox" role="switch" id="isPublicDomain"
+                    v-model="form.isPublicDomain" />
                 </div>
-                <div v-else>Carregando...</div>
-                <i v-if="hasCollectives" class="bi bi-chevron-down transition-transform"
-                  :class="{ 'rotate-180': isIdentityDropdownOpen }" />
+              </div>
+              <div v-if="form.isPublicDomain" class="alert alert-info py-2 px-3 small mt-2 h-auto">
+                <i class="bi bi-info-circle me-1" />
+                Mesmo em domínio público, informe o nome do autor original se souber.
               </div>
 
-              <div v-if="hasCollectives && isIdentityDropdownOpen" class="w-100 bg-off-white rounded mt-1">
-                <div v-for="identity in availableIdentities" :key="identity.id"
-                  class="d-flex align-items-center gap-2 p-2 hover-bg-light cursor-pointer identity-item"
-                  @click="selectIdentity(identity)" role="button">
-                  <div v-if="identity.avatar" class="rounded-circle overflow-hidden" style="width: 40px; height: 40px">
-                    <img :src="identity.avatar" alt="" class="w-100 h-100 object-fit-cover" />
-                  </div>
-                  <div v-else
-                    class="rounded-circle bg-black text-white d-flex align-items-center justify-content-center fw-bold"
-                    style="width: 40px; height: 40px">
-                    {{ identity.initials }}
-                  </div>
-                  <span class="fw-medium">{{ identity.name }}</span>
+              <div v-if="!form.isPublicDomain && !form.unknownAuthor"
+                class="d-flex justify-content-between align-items-center mb-4">
+                <label class="form-check-label text-muted fst-italic small"
+                  :class="{ 'text-negativo-e': isRightsInvalid }" for="hasAuthorization">Tenho permissão expressa do
+                  autor para disponibilizar a
+                  imagem no ARQUIGRAFIA</label>
+                <div class="form-check form-switch p-0 m-0">
+                  <input class="form-check-input m-0" type="checkbox" role="switch" id="hasAuthorization"
+                    v-model="form.hasAuthorization" />
                 </div>
+              </div>
+
+              <div class="mb-2" v-if="!isRightsInvalid">
+                <UiField label="Autoria da imagem" explain="Informe o nome do autor da imagem"
+                  :invalid="isAuthorNameInvalid" invalidMessage="O nome do autor é obrigatório">
+                  <template #default="{ id, ariaInvalid, ariaDescribedby }">
+                    <input :id="id" type="text" class="form-control" :class="{ 'is-invalid': isAuthorNameInvalid }"
+                      placeholder="Nome do autor" v-model="form.authorName" :disabled="form.unknownAuthor"
+                      :aria-invalid="ariaInvalid" :aria-describedby="ariaDescribedby"
+                      @blur="isAuthorNameTouched = true" />
+                  </template>
+                </UiField>
+              </div>
+
+              <div class="d-flex justify-content-between align-items-center mb-4">
+                <label class="form-check-label text-muted fst-italic small" for="unknownAuthor">Não sei quem é o autor
+                  da
+                  imagem</label>
+                <div class="form-check form-switch p-0 m-0">
+                  <input class="form-check-input m-0" type="checkbox" role="switch" id="unknownAuthor"
+                    v-model="form.unknownAuthor" @change="
+                      form.unknownAuthor
+                        ? (form.hasAuthorization = false)
+                        : null
+                      " />
+                </div>
+              </div>
+            </template>
+          </div>
+
+          <div class="mb-4 px-3">
+            <h3 class="form-label text-cinza-e h3 mb-2">Direitos de uso da imagem</h3>
+            <span class="badge bg-secondary fs-6 fw-normal">{{ props.image?.license || form.license }}</span>
+            <p class="text-muted small mt-1">A licença não pode ser alterada após o envio.</p>
+          </div>
+
+          <div class="text-end mt-4 text-muted fst-italic small">
+            Preenchimento obrigatório
+          </div>
+        </section>
+
+        <!-- Seção: Dados Gerais -->
+        <section id="geral" class="py-4">
+          <h2 class="mb-4">Dados gerais</h2>
+
+          <div class="mb-4 px-3">
+            <UiField label="Obra" explain="Informe a obra relacionada">
+              <input type="text" class="form-control" placeholder="Texto exemplo" v-model="form.work" />
+            </UiField>
+          </div>
+
+          <div class="mb-4 px-3">
+            <UiField label="Tags da imagem" explain="Adicione tags para classificar a imagem">
+              <div class="position-relative">
+                <input type="text" class="form-control" placeholder="Digite uma tag e pressione Enter"
+                  v-model="tagInput" @keydown.enter.prevent="addTag" @input="onTagInputChange"
+                  @focus="showTagSuggestions = true" @blur="hideTagSuggestions" autocomplete="off" />
+                <div v-if="
+                  showTagSuggestions &&
+                  (filteredTagSuggestions.length > 0 || canCreateSubject)
+                " class="dropdown-menu w-100 show position-absolute top-100 start-0 mt-1"
+                  style="z-index: 1000; max-height: 300px; overflow-y: auto">
+                  <button v-for="(suggestion, index) in filteredTagSuggestions" :key="index" type="button"
+                    class="dropdown-item" @click="selectTagSuggestion(suggestion.term)">
+                    {{ suggestion.term }}
+                  </button>
+                  <button v-if="canCreateSubject" type="button"
+                    class="dropdown-item text-primary d-flex align-items-center gap-1" :disabled="isCreatingSubject"
+                    @click="createAndAddSubject(tagInput.trim())">
+                    <i class="bi bi-plus-circle" />
+                    <span>{{
+                      isCreatingSubject
+                        ? "Criando..."
+                        : `Criar tag "${tagInput.trim()}"`
+                    }}</span>
+                  </button>
+                </div>
+              </div>
+            </UiField>
+            <div class="d-flex flex-wrap gap-2 mt-2">
+              <div v-for="(tag, index) in form.tags" :key="tag"
+                class="btn btn-outline-secondary btn-sm btn-tag d-inline-flex align-items-center">
+                {{ tag }}
+                <button type="button" class="btn-close ms-2" aria-label="Remover" @click="removeTag(index)" />
               </div>
             </div>
           </div>
 
-          <!-- Seção: Dados Essenciais -->
-          <section id="essenciais" class="py-4 p-4 shadow-sm"
-            :class="[isEssenciaisInvalid ? 'bg-negativo-c' : 'bg-off-white']" style="border-radius: 5px">
-            <h2 class="mb-4">Dados essenciais</h2>
-
-            <div class="mb-4 px-3">
-              <UiField label="Título da imagem" explain="Adicione um título para a imagem" :invalid="isTitleInvalid"
-                invalidMessage="O título da imagem é obrigatório">
-                <template #default="{ id, ariaInvalid, ariaDescribedby }">
-                  <input :id="id" type="text" class="form-control" :class="{ 'is-invalid': isTitleInvalid }"
-                    placeholder="Adicione um título" v-model="form.title" :aria-invalid="ariaInvalid"
-                    :aria-describedby="ariaDescribedby" @blur="isTitleTouched = true" />
-                </template>
-              </UiField>
+          <div class="mb-4 px-3">
+            <UiField label="Descrição da imagem" explain="Adicione uma descrição detalhada da imagem">
+              <textarea class="form-control" rows="5" placeholder="Texto exemplo" v-model="form.description"
+                maxlength="500"></textarea>
+            </UiField>
+            <div class="text-end text-muted small mt-1">
+              Máximo 500 caracteres.
             </div>
+          </div>
 
-            <div class="mb-4 px-3">
-              <div class="term-text-wrapper ">
-                <!-- <div class="d-flex justify-content-between align-items-center mb-2 md:flex-row flex-column gap-2"> -->
-                <h3 class="form-label text-cinza-e h3 mb-0">
-                  Autorizações para publicação
-                </h3>
-                <!-- <a href="#" class="text-decoration-none d-flex align-items-center gap-1 text-muted text-xs"> -->
-                <a href="#" class="term-text-link text-decoration-none d-flex align-items-center gap-1 text-muted">
-                  <i class="bi bi-book" />Revisar Termos e Condições
-                </a>
-              </div>
-
-              <div class="d-flex justify-content-between align-items-center mb-3">
-                <label class="form-check-label text-muted fst-italic small" for="isAuthor">Sou o autor da imagem</label>
-                <div class="form-check form-switch p-0 m-0">
-                  <input class="form-check-input m-0" type="checkbox" role="switch" id="isAuthor"
-                    v-model="form.isAuthor" />
+          <div class="mb-4 px-3">
+            <UiField label="Data da imagem" explain="Informe a data de criação da imagem">
+              <div class="d-flex flex-column gap-3">
+                <div v-if="form.dateType === 'year'" style="width: 120px">
+                  <input type="number" class="form-control" v-model="dateYearInput" placeholder="Ano" />
                 </div>
-              </div>
-
-              <template v-if="!form.isAuthor">
-                <div class="d-flex justify-content-between align-items-center mb-3">
-                  <label class="form-check-label text-muted fst-italic small" for="isPublicDomain">Imagem está em
-                    Domínio Público</label>
-                  <div class="form-check form-switch p-0 m-0">
-                    <input class="form-check-input m-0" type="checkbox" role="switch" id="isPublicDomain"
-                      v-model="form.isPublicDomain" />
-                  </div>
-                </div>
-                <div v-if="form.isPublicDomain" class="alert alert-info py-2 px-3 small mt-2 h-auto">
-                  <i class="bi bi-info-circle me-1" />
-                  Mesmo em domínio público, informe o nome do autor original se souber.
-                </div>
-
-                <div v-if="!form.isPublicDomain && !form.unknownAuthor"
-                  class="d-flex justify-content-between align-items-center mb-4">
-                  <label class="form-check-label text-muted fst-italic small"
-                    :class="{ 'text-negativo-e': isRightsInvalid }" for="hasAuthorization">Tenho permissão expressa do
-                    autor para disponibilizar a
-                    imagem no ARQUIGRAFIA</label>
-                  <div class="form-check form-switch p-0 m-0">
-                    <input class="form-check-input m-0" type="checkbox" role="switch" id="hasAuthorization"
-                      v-model="form.hasAuthorization" />
-                  </div>
-                </div>
-
-                <div class="mb-2" v-if="!isRightsInvalid">
-                  <UiField label="Autoria da imagem" explain="Informe o nome do autor da imagem"
-                    :invalid="isAuthorNameInvalid" invalidMessage="O nome do autor é obrigatório">
-                    <template #default="{ id, ariaInvalid, ariaDescribedby }">
-                      <input :id="id" type="text" class="form-control" :class="{ 'is-invalid': isAuthorNameInvalid }"
-                        placeholder="Nome do autor" v-model="form.authorName" :disabled="form.unknownAuthor"
-                        :aria-invalid="ariaInvalid" :aria-describedby="ariaDescribedby"
-                        @blur="isAuthorNameTouched = true" />
-                    </template>
-                  </UiField>
-                </div>
-
-                <div class="d-flex justify-content-between align-items-center mb-4">
-                  <label class="form-check-label text-muted fst-italic small" for="unknownAuthor">Não sei quem é o autor
-                    da
-                    imagem</label>
-                  <div class="form-check form-switch p-0 m-0">
-                    <input class="form-check-input m-0" type="checkbox" role="switch" id="unknownAuthor"
-                      v-model="form.unknownAuthor" @change="
-                        form.unknownAuthor
-                          ? (form.hasAuthorization = false)
-                          : null
-                        " />
-                  </div>
-                </div>
-              </template>
-            </div>
-
-            <div class="mb-4 px-3">
-              <h3 class="form-label text-cinza-e h3 mb-2">Direitos de uso da imagem</h3>
-              <span class="badge bg-secondary fs-6 fw-normal">{{ props.image?.license || form.license }}</span>
-              <p class="text-muted small mt-1">A licença não pode ser alterada após o envio.</p>
-            </div>
-
-            <div class="text-end mt-4 text-muted fst-italic small">
-              Preenchimento obrigatório
-            </div>
-          </section>
-
-          <!-- Seção: Dados Gerais -->
-          <section id="geral" class="py-4">
-            <h2 class="mb-4">Dados gerais</h2>
-
-            <div class="mb-4 px-3">
-              <UiField label="Obra" explain="Informe a obra relacionada">
-                <input type="text" class="form-control" placeholder="Texto exemplo" v-model="form.work" />
-              </UiField>
-            </div>
-
-            <div class="mb-4 px-3">
-              <UiField label="Tags da imagem" explain="Adicione tags para classificar a imagem">
-                <div class="position-relative">
-                  <input type="text" class="form-control" placeholder="Digite uma tag e pressione Enter"
-                    v-model="tagInput" @keydown.enter.prevent="addTag" @input="onTagInputChange"
-                    @focus="showTagSuggestions = true" @blur="hideTagSuggestions" autocomplete="off" />
-                  <div v-if="
-                    showTagSuggestions &&
-                    (filteredTagSuggestions.length > 0 || canCreateSubject)
-                  " class="dropdown-menu w-100 show position-absolute top-100 start-0 mt-1"
-                    style="z-index: 1000; max-height: 300px; overflow-y: auto">
-                    <button v-for="(suggestion, index) in filteredTagSuggestions" :key="index" type="button"
-                      class="dropdown-item" @click="selectTagSuggestion(suggestion.term)">
-                      {{ suggestion.term }}
-                    </button>
-                    <button v-if="canCreateSubject" type="button"
-                      class="dropdown-item text-primary d-flex align-items-center gap-1" :disabled="isCreatingSubject"
-                      @click="createAndAddSubject(tagInput.trim())">
-                      <i class="bi bi-plus-circle" />
-                      <span>{{
-                        isCreatingSubject
-                          ? "Criando..."
-                          : `Criar tag "${tagInput.trim()}"`
-                      }}</span>
-                    </button>
-                  </div>
-                </div>
-              </UiField>
-              <div class="d-flex flex-wrap gap-2 mt-2">
-                <div v-for="(tag, index) in form.tags" :key="tag"
-                  class="btn btn-outline-secondary btn-sm btn-tag d-inline-flex align-items-center">
-                  {{ tag }}
-                  <button type="button" class="btn-close ms-2" aria-label="Remover" @click="removeTag(index)" />
-                </div>
-              </div>
-            </div>
-
-            <div class="mb-4 px-3">
-              <UiField label="Descrição da imagem" explain="Adicione uma descrição detalhada da imagem">
-                <textarea class="form-control" rows="5" placeholder="Texto exemplo" v-model="form.description"
-                  maxlength="500"></textarea>
-              </UiField>
-              <div class="text-end text-muted small mt-1">
-                Máximo 500 caracteres.
-              </div>
-            </div>
-
-            <div class="mb-4 px-3">
-              <UiField label="Data da imagem" explain="Informe a data de criação da imagem">
-                <div class="d-flex flex-column gap-3">
-                  <div v-if="form.dateType === 'year'" style="width: 120px">
+                <div v-else class="d-flex align-items-center gap-2">
+                  <span>Entre</span>
+                  <div style="width: 120px">
                     <input type="number" class="form-control" v-model="dateYearInput" placeholder="Ano" />
                   </div>
-                  <div v-else class="d-flex align-items-center gap-2">
-                    <span>Entre</span>
-                    <div style="width: 120px">
-                      <input type="number" class="form-control" v-model="dateYearInput" placeholder="Ano" />
-                    </div>
-                    <span>e</span>
-                    <div style="width: 120px">
-                      <input type="number" class="form-control" v-model="dateEndYearInput" placeholder="Ano" />
-                    </div>
-                  </div>
-
-                  <div class="d-flex gap-4">
-                    <div class="form-check">
-                      <input class="form-check-input" type="radio" name="dateType" id="dateTypeYear" value="year"
-                        v-model="form.dateType" />
-                      <label class="form-check-label" for="dateTypeYear">Ano</label>
-                    </div>
-                    <div class="form-check">
-                      <input class="form-check-input" type="radio" name="dateType" id="dateTypeInterval"
-                        value="interval" v-model="form.dateType" />
-                      <label class="form-check-label" for="dateTypeInterval">Intervalo</label>
-                    </div>
-                  </div>
-
-                  <div class="d-flex gap-4">
-                    <div class="form-check">
-                      <input class="form-check-input" type="radio" name="dateAccuracy" id="dateAccExact" value="exact"
-                        v-model="form.dateAccuracy" />
-                      <label class="form-check-label" for="dateAccExact">Data exata</label>
-                    </div>
-                    <div class="form-check">
-                      <input class="form-check-input" type="radio" name="dateAccuracy" id="dateAccApprox"
-                        value="approximate" v-model="form.dateAccuracy" />
-                      <label class="form-check-label" for="dateAccApprox">Data aproximada</label>
-                    </div>
+                  <span>e</span>
+                  <div style="width: 120px">
+                    <input type="number" class="form-control" v-model="dateEndYearInput" placeholder="Ano" />
                   </div>
                 </div>
-              </UiField>
-            </div>
-          </section>
 
-          <!-- Seção: Localização -->
-          <section id="localizacao" class="py-4">
-            <h2 class="mb-4">Localização</h2>
-
-            <div class="mb-4">
-              <UiField label="Buscar por localidade" explain="Busque e selecione a localidade no mapa">
-                <div class="position-relative mb-3">
-                  <div class="input-group">
-                    <input type="text" class="form-control" placeholder="Ex: Av. Paulista, 1578, São Paulo"
-                      v-model="form.location" @keydown.enter.prevent="searchLocation"
-                      @focus="showLocationSuggestions = true" @blur="hideLocationSuggestions" autocomplete="off" />
-                    <button type="button" class="btn btn-outline-secondary" @click="searchLocation"
-                      :disabled="isSearchingLocation">
-                      <span v-if="isSearchingLocation" class="spinner-border spinner-border-sm" role="status" />
-                      <i v-else class="bi bi-search" />
-                    </button>
+                <div class="d-flex gap-4">
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="dateType" id="dateTypeYear" value="year"
+                      v-model="form.dateType" />
+                    <label class="form-check-label" for="dateTypeYear">Ano</label>
                   </div>
-                  <div v-if="
-                    showLocationSuggestions && locationSuggestions.length > 0
-                  " class="dropdown-menu w-100 show position-absolute top-100 start-0 mt-1"
-                    style="z-index: 1000; max-height: 300px; overflow-y: auto">
-                    <button v-for="(suggestion, index) in locationSuggestions" :key="index" type="button"
-                      class="dropdown-item text-wrap small" @click="selectLocationSuggestion(suggestion)">
-                      {{ suggestion.display_name }}
-                    </button>
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="dateType" id="dateTypeInterval" value="interval"
+                      v-model="form.dateType" />
+                    <label class="form-check-label" for="dateTypeInterval">Intervalo</label>
                   </div>
                 </div>
-              </UiField>
 
-              <h3 class="form-label text-cinza-e h3 mb-2">
-                Selecione no mapa a localização de sua imagem
-              </h3>
-
-              <div class="map-container overflow-hidden border" style="height: 400px">
-                <MapLibreMap :style-url="mapStyleUrl" :center="mapCenter" :zoom="mapZoom"
-                  :marker-position="form.coordinates" @map-ready="handleMapReady" @map-error="handleMapError"
-                  @click="handleMapClick" clickable marker-color="#0f89e1">
-                  <MapControls class="position-absolute bottom-0 start-50 translate-middle-x mb-3" @zoom-in="zoomIn"
-                    @zoom-out="zoomOut" />
-                  <button type="button" class="position-absolute top-0 end-0 m-2 btn btn-sm btn-light border"
-                    style="z-index: 1" @click="form.coordinates = null; form.location = ''">
-                    <i class="bi bi-x-circle me-1" />Remover marcador
-                  </button>
-                </MapLibreMap>
+                <div class="d-flex gap-4">
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="dateAccuracy" id="dateAccExact" value="exact"
+                      v-model="form.dateAccuracy" />
+                    <label class="form-check-label" for="dateAccExact">Data exata</label>
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="dateAccuracy" id="dateAccApprox"
+                      value="approximate" v-model="form.dateAccuracy" />
+                    <label class="form-check-label" for="dateAccApprox">Data aproximada</label>
+                  </div>
+                </div>
               </div>
+            </UiField>
+          </div>
+        </section>
+
+        <!-- Seção: Localização -->
+        <section id="localizacao" class="py-4">
+          <h2 class="mb-4">Localização</h2>
+
+          <div class="mb-4">
+            <UiField label="Buscar por localidade" explain="Busque e selecione a localidade no mapa">
+              <div class="position-relative mb-3">
+                <div class="input-group">
+                  <input type="text" class="form-control" placeholder="Ex: Av. Paulista, 1578, São Paulo"
+                    v-model="form.location" @keydown.enter.prevent="searchLocation"
+                    @focus="showLocationSuggestions = true" @blur="hideLocationSuggestions" autocomplete="off" />
+                  <button type="button" class="btn btn-outline-secondary" @click="searchLocation"
+                    :disabled="isSearchingLocation">
+                    <span v-if="isSearchingLocation" class="spinner-border spinner-border-sm" role="status" />
+                    <i v-else class="bi bi-search" />
+                  </button>
+                </div>
+                <div v-if="
+                  showLocationSuggestions && locationSuggestions.length > 0
+                " class="dropdown-menu w-100 show position-absolute top-100 start-0 mt-1"
+                  style="z-index: 1000; max-height: 300px; overflow-y: auto">
+                  <button v-for="(suggestion, index) in locationSuggestions" :key="index" type="button"
+                    class="dropdown-item text-wrap small" @click="selectLocationSuggestion(suggestion)">
+                    {{ suggestion.display_name }}
+                  </button>
+                </div>
+              </div>
+            </UiField>
+
+            <h3 class="form-label text-cinza-e h3 mb-2">
+              Selecione no mapa a localização de sua imagem
+            </h3>
+
+            <div class="map-container overflow-hidden border" style="height: 400px">
+              <MapLibreMap :style-url="mapStyleUrl" :center="mapCenter" :zoom="mapZoom"
+                :marker-position="form.coordinates" @map-ready="handleMapReady" @map-error="handleMapError"
+                @click="handleMapClick" clickable marker-color="#0f89e1">
+                <MapControls class="position-absolute bottom-0 start-50 translate-middle-x mb-3" @zoom-in="zoomIn"
+                  @zoom-out="zoomOut" />
+                <button type="button" class="position-absolute top-0 end-0 m-2 btn btn-sm btn-light border"
+                  style="z-index: 1" @click="form.coordinates = null; form.location = ''">
+                  <i class="bi bi-x-circle me-1" />Remover marcador
+                </button>
+              </MapLibreMap>
             </div>
-          </section>
-        </div>
+          </div>
+        </section>
       </div>
     </div>
   </div>
@@ -344,7 +353,7 @@
       <button class="btn btn-outline-secondary" @click="handleCancel">
         Cancelar
       </button>
-      <button class="btn btn-primary" :disabled="!isFormValid || isSaving" @click="handleSubmit">
+      <button class="btn btn-primary" :disabled="!isFormValid || isSaving || isSaved" @click="handleSubmit">
         <span v-if="isSaving" class="spinner-border spinner-border-sm me-2" role="status" />
         {{ isSaving ? "Salvando..." : "Salvar alterações" }}
       </button>
@@ -375,6 +384,7 @@ const emit = defineEmits(["updated"]);
 
 const router = useRouter();
 const authStore = useAuthStore();
+const isSaved = ref(false);
 
 const buildPayload = async () => {
   const photographerUuid = await resolvePhotographerUuid(form.value);
@@ -504,6 +514,7 @@ const handleSubmit = async () => {
     });
 
     showSuccess("Imagem atualizada com sucesso!");
+    isSaved.value = true;
     emit("updated");
 
     setTimeout(() => {
@@ -683,5 +694,22 @@ $breakpoint-md: 768px;
   max-height: 500px;
   object-fit: contain;
   background: #f8f9fa;
+}
+
+.skeleton {
+  background: linear-gradient(90deg, #e2e2e2 25%, #f0f0f0 50%, #e2e2e2 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s infinite;
+  border-radius: 4px;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
 }
 </style>

--- a/src/components/imageDetail/ImageMetadataEdit.vue
+++ b/src/components/imageDetail/ImageMetadataEdit.vue
@@ -1,0 +1,651 @@
+<template>
+  <div class="container py-4 position-relative">
+    <transition name="fade">
+      <div class="upload-box__alert" v-if="showAlert">
+        <div class="alert h-auto fs-6 border border-start-3" :class="alertType === 'success'
+          ? 'alert-success bg-positivo-c text-positivo-e border-success'
+          : 'alert-danger bg-negativo-c text-negativo-e border-danger'
+          " role="alert">
+          <i :class="alertType === 'success'
+            ? 'bi bi-check-circle-fill text-positivo-e'
+            : 'bi bi-exclamation-triangle-fill text-negativo-e'
+            " />
+          <span>{{ alertMessage }}</span>
+          <button type="button" :class="[
+            'btn-close',
+            alertType === 'success' ? 'text-positivo-e' : 'text-negativo-e',
+          ]" @click="showAlert = false" />
+        </div>
+      </div>
+    </transition>
+
+    <div class="row align-items-start gy-4 metadata-upload__layout">
+
+      <!-- Formulário (lado direito) -->
+      <div>
+        <div
+          class="d-flex flex-column flex-md-row justify-content-start align-items-start align-items-md-center gap-3 bg-white py-2">
+          <ul class="nav nav-underline">
+            <li v-for="tab in tabs" :key="tab.section" class="nav-item">
+              <a class="nav-link" :href="`#${tab.section}`" :class="{ active: currentSection === tab.section }"
+                @click="selectTab(tab.section)">
+                {{ tab.label }}
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        <div class="metadata-sections">
+          <!-- Publicando como -->
+          <div class="bg-off-white p-2 mb-4" style="border-radius: 5px">
+            <h2 class="text-muted fst-italic small mb-2">
+              Você está editando como
+            </h2>
+            <div>
+              <div class="d-flex align-items-center p-2" :class="{
+                'justify-content-between cursor-pointer rounded': hasCollectives,
+              }" @click="hasCollectives ? toggleIdentityDropdown() : null"
+                :role="hasCollectives ? 'button' : undefined">
+                <div class="d-flex align-items-center gap-2" v-if="selectedIdentity">
+                  <div v-if="selectedIdentity.avatar" class="rounded-circle overflow-hidden"
+                    style="width: 40px; height: 40px">
+                    <img :src="selectedIdentity.avatar" alt="" class="w-100 h-100 object-fit-cover" />
+                  </div>
+                  <div v-else
+                    class="rounded-circle bg-black text-white d-flex align-items-center justify-content-center fw-bold"
+                    style="width: 40px; height: 40px">
+                    {{ selectedIdentity.initials }}
+                  </div>
+                  <span class="fw-medium">{{ selectedIdentity.name }}</span>
+                </div>
+                <div v-else>Carregando...</div>
+                <i v-if="hasCollectives" class="bi bi-chevron-down transition-transform"
+                  :class="{ 'rotate-180': isIdentityDropdownOpen }" />
+              </div>
+
+              <div v-if="hasCollectives && isIdentityDropdownOpen" class="w-100 bg-off-white rounded mt-1">
+                <div v-for="identity in availableIdentities" :key="identity.id"
+                  class="d-flex align-items-center gap-2 p-2 hover-bg-light cursor-pointer identity-item"
+                  @click="selectIdentity(identity)" role="button">
+                  <div v-if="identity.avatar" class="rounded-circle overflow-hidden" style="width: 40px; height: 40px">
+                    <img :src="identity.avatar" alt="" class="w-100 h-100 object-fit-cover" />
+                  </div>
+                  <div v-else
+                    class="rounded-circle bg-black text-white d-flex align-items-center justify-content-center fw-bold"
+                    style="width: 40px; height: 40px">
+                    {{ identity.initials }}
+                  </div>
+                  <span class="fw-medium">{{ identity.name }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Seção: Dados Essenciais -->
+          <section id="essenciais" class="py-4 p-4 shadow-sm"
+            :class="[isEssenciaisInvalid ? 'bg-negativo-c' : 'bg-off-white']" style="border-radius: 5px">
+            <h2 class="mb-4">Dados essenciais</h2>
+
+            <div class="mb-4 px-3">
+              <UiField label="Título da imagem" explain="Adicione um título para a imagem" :invalid="isTitleInvalid"
+                invalidMessage="O título da imagem é obrigatório">
+                <template #default="{ id, ariaInvalid, ariaDescribedby }">
+                  <input :id="id" type="text" class="form-control" :class="{ 'is-invalid': isTitleInvalid }"
+                    placeholder="Adicione um título" v-model="form.title" :aria-invalid="ariaInvalid"
+                    :aria-describedby="ariaDescribedby" @blur="isTitleTouched = true" />
+                </template>
+              </UiField>
+            </div>
+
+            <div class="mb-4 px-3">
+              <div class="d-flex justify-content-between align-items-center mb-2">
+                <h3 class="form-label text-cinza-e h3 mb-0">
+                  Autorizações para publicação
+                </h3>
+                <a href="#" class="text-decoration-none d-flex align-items-center gap-1 text-muted small">
+                  <i class="bi bi-book" /> Revisar Termos e Condições
+                </a>
+              </div>
+
+              <div class="d-flex justify-content-between align-items-center mb-3">
+                <label class="form-check-label text-muted fst-italic small" for="isAuthor">Sou o autor da imagem</label>
+                <div class="form-check form-switch p-0 m-0">
+                  <input class="form-check-input m-0" type="checkbox" role="switch" id="isAuthor"
+                    v-model="form.isAuthor" />
+                </div>
+              </div>
+
+              <template v-if="!form.isAuthor">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                  <label class="form-check-label text-muted fst-italic small" for="isPublicDomain">Imagem está em
+                    Domínio Público</label>
+                  <div class="form-check form-switch p-0 m-0">
+                    <input class="form-check-input m-0" type="checkbox" role="switch" id="isPublicDomain"
+                      v-model="form.isPublicDomain" />
+                  </div>
+                </div>
+                <div v-if="form.isPublicDomain" class="alert alert-info py-2 px-3 small mt-2">
+                  <i class="bi bi-info-circle me-1" />
+                  Mesmo em domínio público, informe o nome do autor original se souber.
+                </div>
+
+                <div v-if="!form.isPublicDomain && !form.unknownAuthor"
+                  class="d-flex justify-content-between align-items-center mb-4">
+                  <label class="form-check-label text-muted fst-italic small"
+                    :class="{ 'text-negativo-e': isRightsInvalid }" for="hasAuthorization">Tenho permissão expressa do
+                    autor para disponibilizar a
+                    imagem no ARQUIGRAFIA</label>
+                  <div class="form-check form-switch p-0 m-0">
+                    <input class="form-check-input m-0" type="checkbox" role="switch" id="hasAuthorization"
+                      v-model="form.hasAuthorization" />
+                  </div>
+                </div>
+
+                <div class="mb-2" v-if="!isRightsInvalid">
+                  <UiField label="Autoria da imagem" explain="Informe o nome do autor da imagem"
+                    :invalid="isAuthorNameInvalid" invalidMessage="O nome do autor é obrigatório">
+                    <template #default="{ id, ariaInvalid, ariaDescribedby }">
+                      <input :id="id" type="text" class="form-control" :class="{ 'is-invalid': isAuthorNameInvalid }"
+                        placeholder="Nome do autor" v-model="form.authorName" :disabled="form.unknownAuthor"
+                        :aria-invalid="ariaInvalid" :aria-describedby="ariaDescribedby"
+                        @blur="isAuthorNameTouched = true" />
+                    </template>
+                  </UiField>
+                </div>
+
+                <div class="d-flex justify-content-between align-items-center mb-4">
+                  <label class="form-check-label text-muted fst-italic small" for="unknownAuthor">Não sei quem é o autor
+                    da
+                    imagem</label>
+                  <div class="form-check form-switch p-0 m-0">
+                    <input class="form-check-input m-0" type="checkbox" role="switch" id="unknownAuthor"
+                      v-model="form.unknownAuthor" @change="
+                        form.unknownAuthor
+                          ? (form.hasAuthorization = false)
+                          : null
+                        " />
+                  </div>
+                </div>
+              </template>
+            </div>
+
+            <div class="mb-4 px-3">
+              <h3 class="form-label text-cinza-e h3 mb-2">Direitos de uso da imagem</h3>
+              <span class="badge bg-secondary fs-6 fw-normal">{{ props.image?.license || form.license }}</span>
+              <p class="text-muted small mt-1">A licença não pode ser alterada após o envio.</p>
+            </div>
+
+            <div class="text-end mt-4 text-muted fst-italic small">
+              Preenchimento obrigatório
+            </div>
+          </section>
+
+          <!-- Seção: Dados Gerais -->
+          <section id="geral" class="py-4">
+            <h2 class="mb-4">Dados gerais</h2>
+
+            <div class="mb-4 px-3">
+              <UiField label="Obra" explain="Informe a obra relacionada">
+                <input type="text" class="form-control" placeholder="Texto exemplo" v-model="form.work" />
+              </UiField>
+            </div>
+
+            <div class="mb-4 px-3">
+              <UiField label="Tags da imagem" explain="Adicione tags para classificar a imagem">
+                <div class="position-relative">
+                  <input type="text" class="form-control" placeholder="Digite uma tag e pressione Enter"
+                    v-model="tagInput" @keydown.enter.prevent="addTag" @input="onTagInputChange"
+                    @focus="showTagSuggestions = true" @blur="hideTagSuggestions" autocomplete="off" />
+                  <div v-if="
+                    showTagSuggestions &&
+                    (filteredTagSuggestions.length > 0 || canCreateSubject)
+                  " class="dropdown-menu w-100 show position-absolute top-100 start-0 mt-1"
+                    style="z-index: 1000; max-height: 300px; overflow-y: auto">
+                    <button v-for="(suggestion, index) in filteredTagSuggestions" :key="index" type="button"
+                      class="dropdown-item" @click="selectTagSuggestion(suggestion.term)">
+                      {{ suggestion.term }}
+                    </button>
+                    <button v-if="canCreateSubject" type="button"
+                      class="dropdown-item text-primary d-flex align-items-center gap-1" :disabled="isCreatingSubject"
+                      @click="createAndAddSubject(tagInput.trim())">
+                      <i class="bi bi-plus-circle" />
+                      <span>{{
+                        isCreatingSubject
+                          ? "Criando..."
+                          : `Criar tag "${tagInput.trim()}"`
+                      }}</span>
+                    </button>
+                  </div>
+                </div>
+              </UiField>
+              <div class="d-flex flex-wrap gap-2 mt-2">
+                <div v-for="(tag, index) in form.tags" :key="tag"
+                  class="btn btn-outline-secondary btn-sm btn-tag d-inline-flex align-items-center">
+                  {{ tag }}
+                  <button type="button" class="btn-close ms-2" aria-label="Remover" @click="removeTag(index)" />
+                </div>
+              </div>
+            </div>
+
+            <div class="mb-4 px-3">
+              <UiField label="Descrição da imagem" explain="Adicione uma descrição detalhada da imagem">
+                <textarea class="form-control" rows="5" placeholder="Texto exemplo" v-model="form.description"
+                  maxlength="500"></textarea>
+              </UiField>
+              <div class="text-end text-muted small mt-1">
+                Máximo 500 caracteres.
+              </div>
+            </div>
+
+            <div class="mb-4 px-3">
+              <UiField label="Data da imagem" explain="Informe a data de criação da imagem">
+                <div class="d-flex flex-column gap-3">
+                  <div v-if="form.dateType === 'year'" style="width: 120px">
+                    <input type="number" class="form-control" v-model="dateYearInput" placeholder="Ano" />
+                  </div>
+                  <div v-else class="d-flex align-items-center gap-2">
+                    <span>Entre</span>
+                    <div style="width: 120px">
+                      <input type="number" class="form-control" v-model="dateYearInput" placeholder="Ano" />
+                    </div>
+                    <span>e</span>
+                    <div style="width: 120px">
+                      <input type="number" class="form-control" v-model="dateEndYearInput" placeholder="Ano" />
+                    </div>
+                  </div>
+
+                  <div class="d-flex gap-4">
+                    <div class="form-check">
+                      <input class="form-check-input" type="radio" name="dateType" id="dateTypeYear" value="year"
+                        v-model="form.dateType" />
+                      <label class="form-check-label" for="dateTypeYear">Ano</label>
+                    </div>
+                    <div class="form-check">
+                      <input class="form-check-input" type="radio" name="dateType" id="dateTypeInterval"
+                        value="interval" v-model="form.dateType" />
+                      <label class="form-check-label" for="dateTypeInterval">Intervalo</label>
+                    </div>
+                  </div>
+
+                  <div class="d-flex gap-4">
+                    <div class="form-check">
+                      <input class="form-check-input" type="radio" name="dateAccuracy" id="dateAccExact" value="exact"
+                        v-model="form.dateAccuracy" />
+                      <label class="form-check-label" for="dateAccExact">Data exata</label>
+                    </div>
+                    <div class="form-check">
+                      <input class="form-check-input" type="radio" name="dateAccuracy" id="dateAccApprox"
+                        value="approximate" v-model="form.dateAccuracy" />
+                      <label class="form-check-label" for="dateAccApprox">Data aproximada</label>
+                    </div>
+                  </div>
+                </div>
+              </UiField>
+            </div>
+          </section>
+
+          <!-- Seção: Localização -->
+          <section id="localizacao" class="py-4">
+            <h2 class="mb-4">Localização</h2>
+
+            <div class="mb-4">
+              <UiField label="Buscar por localidade" explain="Busque e selecione a localidade no mapa">
+                <div class="position-relative mb-3">
+                  <div class="input-group">
+                    <input type="text" class="form-control" placeholder="Ex: Av. Paulista, 1578, São Paulo"
+                      v-model="form.location" @keydown.enter.prevent="searchLocation"
+                      @focus="showLocationSuggestions = true" @blur="hideLocationSuggestions" autocomplete="off" />
+                    <button type="button" class="btn btn-outline-secondary" @click="searchLocation"
+                      :disabled="isSearchingLocation">
+                      <span v-if="isSearchingLocation" class="spinner-border spinner-border-sm" role="status" />
+                      <i v-else class="bi bi-search" />
+                    </button>
+                  </div>
+                  <div v-if="
+                    showLocationSuggestions && locationSuggestions.length > 0
+                  " class="dropdown-menu w-100 show position-absolute top-100 start-0 mt-1"
+                    style="z-index: 1000; max-height: 300px; overflow-y: auto">
+                    <button v-for="(suggestion, index) in locationSuggestions" :key="index" type="button"
+                      class="dropdown-item text-wrap small" @click="selectLocationSuggestion(suggestion)">
+                      {{ suggestion.display_name }}
+                    </button>
+                  </div>
+                </div>
+              </UiField>
+
+              <h3 class="form-label text-cinza-e h3 mb-2">
+                Selecione no mapa a localização de sua imagem
+              </h3>
+
+              <div class="map-container overflow-hidden border" style="height: 400px">
+                <MapLibreMap :style-url="mapStyleUrl" :center="mapCenter" :zoom="mapZoom"
+                  :marker-position="form.coordinates" @map-ready="handleMapReady" @map-error="handleMapError"
+                  @click="handleMapClick" clickable marker-color="#0f89e1">
+                  <MapControls class="position-absolute bottom-0 start-50 translate-middle-x mb-3" @zoom-in="zoomIn"
+                    @zoom-out="zoomOut" />
+                  <button type="button" class="position-absolute top-0 end-0 m-2 btn btn-sm btn-light border"
+                    style="z-index: 1" @click="form.coordinates = null; form.location = ''">
+                    <i class="bi bi-x-circle me-1" />Remover marcador
+                  </button>
+                </MapLibreMap>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Barra de ações -->
+  <div class="preview-actions-bar">
+    <div class="d-flex gap-3">
+      <button class="btn btn-outline-secondary" @click="handleCancel">
+        Cancelar
+      </button>
+      <button class="btn btn-primary" :disabled="!isFormValid || isSaving" @click="handleSubmit">
+        <span v-if="isSaving" class="spinner-border spinner-border-sm me-2" role="status" />
+        {{ isSaving ? "Salvando..." : "Salvar alterações" }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from "vue";
+import axios from "@/axios";
+import UiField from "@/components/ui/UiField.vue";
+import MapLibreMap from "@/components/map/MapLibreMap.vue";
+import MapControls from "@/components/map/MapControls.vue";
+import { useAuthStore } from "@/store/auth";
+import { useRouter } from "vue-router";
+import { useImageForm } from "@/composables/useImageForm";
+
+defineOptions({ name: "ImageMetadataEdit" });
+
+const props = defineProps({
+  /** ID da imagem a ser editada — obrigatório */
+  image: {
+    type: Object,
+    default: null,
+  },
+});
+const emit = defineEmits(["updated"]);
+
+const router = useRouter();
+const authStore = useAuthStore();
+
+const buildPayload = async () => {
+  const photographerUuid = await resolvePhotographerUuid(form.value);
+  const subjectUuids = resolveSubjectUuids(form.value.tags);
+
+  const payload = {
+    title: form.value.title || null,
+    description: form.value.description || null,
+    photographer: photographerUuid || null,
+    subjects: subjectUuids.length ? subjectUuids : null,
+    latitude: form.value.coordinates?.lat
+      ? parseFloat(form.value.coordinates.lat.toFixed(8))
+      : null,
+    longitude: form.value.coordinates?.lng
+      ? parseFloat(form.value.coordinates.lng.toFixed(8))
+      : null,
+    location_label: form.value.location || null,
+    earliest_date: form.value.date || null,
+    latest_date: form.value.dateEnd || null,
+    circa: form.value.dateAccuracy === "approximate",
+  };
+
+  return Object.fromEntries(
+    Object.entries(payload).filter(([key, v]) =>
+      v !== null || ["latitude", "longitude", "location_label"].includes(key))
+  );
+};
+
+// ─── Composable 
+const {
+  tabs,
+  currentSection,
+  selectTab,
+  showAlert,
+  alertMessage,
+  alertType,
+  showError,
+  showSuccess,
+  isIdentityDropdownOpen,
+  selectedIdentity,
+  hasCollectives,
+  availableIdentities,
+  toggleIdentityDropdown,
+  selectIdentity,
+  form,
+  populateFormFromApi,
+  isTitleTouched,
+  isAuthorNameTouched,
+  isTitleInvalid,
+  isAuthorNameInvalid,
+  isRightsInvalid,
+  isEssenciaisInvalid,
+  isFormValid,
+  touchAllFields,
+  dateYearInput,
+  dateEndYearInput,
+  mapStyleUrl,
+  mapCenter,
+  mapZoom,
+  handleMapReady,
+  handleMapError,
+  handleMapClick,
+  zoomIn,
+  zoomOut,
+  locationSuggestions,
+  showLocationSuggestions,
+  searchLocation,
+  isSearchingLocation,
+  selectLocationSuggestion,
+  hideLocationSuggestions,
+  tagInput,
+  filteredTagSuggestions,
+  showTagSuggestions,
+  isCreatingSubject,
+  canCreateSubject,
+  onTagInputChange,
+  hideTagSuggestions,
+  selectTagSuggestion,
+  createAndAddSubject,
+  addTag,
+  removeTag,
+  resolvePhotographerUuid,
+  resolveSubjectUuids,
+  loadFormDependencies,
+} = useImageForm();
+
+// ─── Estado local (exclusivo de edição) 
+const loadingImage = ref(true);
+const isSaving = ref(false);
+
+// ─── Inicialização 
+watch(
+  () => props.image,
+  async (newImage) => {
+    if (!newImage) {
+      loadingImage.value = false;
+      return;
+    }
+
+    await loadFormDependencies();
+
+    populateFormFromApi(newImage, authStore.loggedUser?.name);
+    loadingImage.value = false;
+  },
+  { immediate: true }
+);
+
+const handleSubmit = async () => {
+  touchAllFields();
+
+  if (!isFormValid.value) {
+    showError("Por favor, preencha todos os dados obrigatórios.");
+    return;
+  }
+
+  isSaving.value = true;
+
+  try {
+
+    const payload = await buildPayload();
+
+    await axios.put(`/api/images/${props.image.id}`, payload, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: authStore.authHeader,
+      },
+    });
+
+    showSuccess("Imagem atualizada com sucesso!");
+    emit("updated");
+
+    setTimeout(() => {
+      router.push({ name: "image-detail-dados", params: { id: props.image.id } });
+    }, 1500);
+  } catch (error) {
+    console.error("Erro ao atualizar imagem:", error);
+    showError(
+      error.response?.data?.message ||
+      "Erro ao salvar alterações. Por favor, tente novamente."
+    );
+  } finally {
+    isSaving.value = false;
+  }
+};
+
+// ─── Cancelar ─────────────────────────────────────────────────────────────────
+const handleCancel = () => {
+  router.push({ name: "image-detail-dados", params: { id: props.image.id } });
+};
+</script>
+
+<style lang="scss" scoped>
+@use "@/scss/variables" as *;
+$breakpoint-md: 768px;
+
+@mixin md {
+  @media (min-width: #{$breakpoint-md}) {
+    @content;
+  }
+}
+
+.upload-box__alert {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 90%;
+  z-index: 1050;
+  width: max-content;
+
+  @media (min-width: 768px) {
+    max-width: 50%;
+  }
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+.fade-enter-to,
+.fade-leave-from {
+  opacity: 1;
+}
+
+.form-check-input[role="switch"]:checked {
+  background-color: var(--Azul_M);
+  border-color: var(--Azul_M);
+}
+
+.cursor-pointer {
+  cursor: pointer;
+}
+
+.hover-bg-light:hover {
+  background-color: #f8f9fa;
+}
+
+.transition-transform {
+  transition: transform 0.2s ease-in-out;
+}
+
+.rotate-180 {
+  transform: rotate(180deg);
+}
+
+.identity-item {
+  border-top: 1px solid color-mix(in srgb, var(--Cinza_C), transparent 50%);
+}
+
+.preview-actions-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: white;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
+  box-shadow: 2px -2px 5px 2px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+
+  .d-flex.gap-3 {
+    width: 100%;
+    justify-content: flex-end;
+
+    .btn {
+      flex: 1;
+    }
+  }
+
+  @include md {
+    flex-direction: row;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 3rem;
+    padding: 1rem 2rem;
+
+    .d-flex.gap-3 {
+      width: auto;
+
+      .btn {
+        flex: unset;
+      }
+    }
+  }
+}
+
+.preview-actions-bar button {
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 150%;
+}
+
+@media (min-width: 768px) {
+  .sticky-preview-panel {
+    position: sticky;
+    top: 20px;
+    align-self: flex-start;
+  }
+}
+
+.image-edit__preview img {
+  width: 100%;
+  max-height: 500px;
+  object-fit: contain;
+  background: #f8f9fa;
+}
+</style>

--- a/src/composables/useImageForm.js
+++ b/src/composables/useImageForm.js
@@ -1,0 +1,561 @@
+import { ref, computed, markRaw, watch } from "vue";
+import { useVracStore } from "@/store/vrac";
+import { useAuthStore } from "@/store/auth";
+import { storeToRefs } from "pinia";
+import { formatDate, parseYearFromDateString } from "@/helpers/dateUtils";
+import Fuse from "fuse.js";
+
+
+export function useImageForm() {
+  const vracStore = useVracStore();
+  const authStore = useAuthStore();
+  const { loggedUser } = storeToRefs(authStore);
+
+  // ─── Tabs
+  const tabs = [
+    { label: "Essenciais", section: "essenciais" },
+    { label: "Geral", section: "geral" },
+    { label: "Localização", section: "localizacao" },
+  ];
+
+  const currentSection = ref("essenciais");
+  const selectTab = (section) => { currentSection.value = section; };
+
+  // ─── Alert 
+  const showAlert = ref(false);
+  const alertMessage = ref("");
+  const alertType = ref("error");
+
+  const showError = (message) => {
+    alertType.value = "error";
+    alertMessage.value = message;
+    showAlert.value = true;
+  };
+
+  const showSuccess = (message) => {
+    alertType.value = "success";
+    alertMessage.value = message;
+    showAlert.value = true;
+  };
+
+  // ─── Identidade (publicar como) 
+  const isIdentityDropdownOpen = ref(false);
+  const selectedIdentityId = ref(null);
+
+  const getInitials = (name) => name?.charAt(0).toUpperCase() || "?";
+
+  const publishingIdentities = computed(() => {
+    if (!loggedUser.value) return [];
+    const user = loggedUser.value;
+    const identities = [
+      {
+        id: user.id,
+        type: "user",
+        name: user.name || user.username,
+        avatar: user.avatar || null,
+        initials: user.initials || getInitials(user.name || user.username),
+      },
+    ];
+    if (Array.isArray(user.collectives)) {
+      for (const collective of user.collectives) {
+        identities.push({
+          id: collective.id,
+          type: "collective",
+          name: collective.name,
+          avatar: collective.avatar_path || null,
+          initials: getInitials(collective.name),
+        });
+      }
+    }
+    return identities;
+  });
+
+  const selectedIdentity = computed(() => {
+    if (!publishingIdentities.value.length) return null;
+    if (!selectedIdentityId.value) return publishingIdentities.value[0];
+    return (
+      publishingIdentities.value.find((i) => i.id === selectedIdentityId.value) ||
+      publishingIdentities.value[0]
+    );
+  });
+
+  const hasCollectives = computed(
+    () =>
+      Array.isArray(loggedUser.value?.collectives) &&
+      loggedUser.value.collectives.length > 0
+  );
+
+  const availableIdentities = computed(() =>
+    publishingIdentities.value.filter(
+      (identity) => identity.id !== selectedIdentity.value?.id
+    )
+  );
+
+  const toggleIdentityDropdown = () => {
+    isIdentityDropdownOpen.value = !isIdentityDropdownOpen.value;
+  };
+
+  const selectIdentity = (identity) => {
+    selectedIdentityId.value = identity.id;
+    isIdentityDropdownOpen.value = false;
+  };
+
+  // ─── Form state 
+  const defaultForm = {
+    title: "",
+    isAuthor: true,
+    isPublicDomain: false,
+    authorName: "",
+    unknownAuthor: false,
+    hasAuthorization: true,
+    work: "",
+    tags: [],
+    description: "",
+    date: "",
+    dateEnd: "",
+    dateType: "year",
+    dateAccuracy: "exact",
+    location: "",
+    coordinates: null,
+  };
+
+  const form = ref({ ...defaultForm });
+
+  watch(() => form.value.dateType, (newType) => {
+    if (newType === "year") {
+      // Sincroniza dateEnd com date ao voltar para ano único
+      const year = parseYearFromDateString(form.value.date);
+      if (year) {
+        form.value.dateEnd = yearToDateString(year, true);
+      }
+    }
+  });
+
+  const resetForm = () => {
+    form.value = { ...defaultForm, tags: [] };
+    isTitleTouched.value = false;
+    isAuthorNameTouched.value = false;
+  };
+
+  // ─── Validações
+  const isTitleTouched = ref(false);
+  const isAuthorNameTouched = ref(false);
+
+  const isTitleInvalid = computed(
+    () => isTitleTouched.value && !form.value.title.trim()
+  );
+
+  const isAuthorNameInvalid = computed(() => {
+    const shouldValidate =
+      !form.value.isAuthor &&
+      !form.value.isPublicDomain &&
+      form.value.hasAuthorization &&
+      !form.value.unknownAuthor;
+    return (
+      shouldValidate &&
+      isAuthorNameTouched.value &&
+      !form.value.authorName.trim()
+    );
+  });
+
+  const isRightsInvalid = computed(
+    () =>
+      !form.value.isAuthor &&
+      !form.value.isPublicDomain &&
+      !form.value.hasAuthorization
+  );
+
+  const isEssenciaisInvalid = computed(
+    () => isRightsInvalid.value || isTitleInvalid.value || isAuthorNameInvalid.value
+  );
+
+  const isFormValid = computed(() => {
+    if (!form.value.title?.trim()) { return false; }
+    if (form.value.isAuthor || form.value.isPublicDomain) { return true; }
+    if (!form.value.hasAuthorization && !form.value.unknownAuthor) { return false; }
+    if (
+      form.value.hasAuthorization &&
+      !form.value.unknownAuthor &&
+      !form.value.authorName?.trim()
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  const touchAllFields = () => {
+    isTitleTouched.value = true;
+    isAuthorNameTouched.value = true;
+  };
+
+  // ─── Data helpers ────────────────────────────────────────────────────────────
+  const yearToDateString = (year, isEnd = false) => {
+    if (!year) return "";
+    const parsedYear = parseInt(year, 10);
+    if (isNaN(parsedYear)) return "";
+    return formatDate(parsedYear, isEnd ? 12 : 1, isEnd ? 31 : 1);
+  };
+
+  const dateYearInput = computed({
+    get() {
+      const dateStr = form.value.date;
+      if (!dateStr) return "";
+      const year = parseYearFromDateString(dateStr);
+      return year ? year.toString() : "";
+    },
+    set(yearStr) {
+      form.value.date = yearToDateString(yearStr, false);
+      form.value.dateEnd = yearToDateString(yearStr, true);
+    },
+  });
+
+  const dateEndYearInput = computed({
+    get() {
+      const dateStr = form.value.dateEnd;
+      if (!dateStr) return "";
+      const year = parseYearFromDateString(dateStr);
+      return year ? year.toString() : "";
+    },
+    set(yearStr) {
+      form.value.dateEnd = yearToDateString(yearStr, true);
+    },
+  });
+
+  // ─── Mapa ────────────────────────────────────────────────────────────────────
+  const mapStyleUrl = "https://tiles.openfreemap.org/styles/positron";
+  const mapCenter = [-51.9253, -14.235];
+  const mapZoom = 2;
+  const mapInstance = ref(null);
+
+  const handleMapReady = (map) => { mapInstance.value = markRaw(map); };
+  const handleMapError = (error) => { console.error("Erro no mapa:", error); };
+  const handleMapClick = ({ lng, lat }) => { form.value.coordinates = { lng, lat }; };
+  const zoomIn = () => { mapInstance.value?.zoomIn(); };
+  const zoomOut = () => { mapInstance.value?.zoomOut(); };
+
+  // ─── Localização / geocoding ─────────────────────────────────────────────────
+  const locationSuggestions = ref([]);
+  const showLocationSuggestions = ref(false);
+  const isSearchingLocation = ref(false);
+
+  const searchLocation = async () => {
+    const query = form.value.location.trim();
+    if (!query || query.length < 3) {
+      locationSuggestions.value = [];
+      return;
+    }
+    isSearchingLocation.value = true;
+    try {
+      const response = await fetch(
+        `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=5`,
+        { headers: { "Accept-Language": "pt-BR,pt" } }
+      );
+      locationSuggestions.value = await response.json();
+      showLocationSuggestions.value = true;
+
+    } catch (error) {
+      console.warn("Erro ao buscar localidade:", error);
+    } finally {
+      isSearchingLocation.value = false;
+    }
+  };
+
+  const selectLocationSuggestion = (suggestion) => {
+    const lng = parseFloat(suggestion.lon);
+    const lat = parseFloat(suggestion.lat);
+    form.value.location = suggestion.display_name;
+    form.value.coordinates = { lng, lat };
+    mapInstance.value?.flyTo({ center: [lng, lat], zoom: 14 });
+    locationSuggestions.value = [];
+    showLocationSuggestions.value = false;
+  };
+
+  const hideLocationSuggestions = () => {
+    setTimeout(() => { showLocationSuggestions.value = false; }, 200);
+  };
+
+  // ─── Tags / subjects ─────────────────────────────────────────────────────────
+  const tagInput = ref("");
+  const allSubjects = ref([]);
+  const filteredTagSuggestions = ref([]);
+  const showTagSuggestions = ref(false);
+  const isCreatingSubject = ref(false);
+  let fuseInstance = null;
+  let debounceTimer = null;
+
+  const canCreateSubject = computed(() => {
+    const term = tagInput.value.trim();
+    if (!term) return false;
+    if (form.value.tags.includes(term)) return false;
+    return !allSubjects.value.some(
+      (s) => s.term.toLowerCase() === term.toLowerCase()
+    );
+  });
+
+  const initFuse = () => {
+    fuseInstance = new Fuse(allSubjects.value, {
+      keys: ["term"],
+      threshold: 0.3,
+      includeScore: true,
+    });
+  };
+
+  const onTagInputChange = () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      if (!tagInput.value.trim()) {
+        filteredTagSuggestions.value = [];
+        return;
+      }
+      if (fuseInstance) {
+        filteredTagSuggestions.value = fuseInstance
+          .search(tagInput.value)
+          .map((r) => r.item)
+          .filter((item) => !form.value.tags.includes(item.term))
+          .slice(0, 10);
+      }
+    }, 300);
+  };
+
+  const hideTagSuggestions = () => {
+    setTimeout(() => { showTagSuggestions.value = false; }, 200);
+  };
+
+  const selectTagSuggestion = (term) => {
+    if (!form.value.tags.includes(term)) {
+      form.value.tags.push(term);
+    }
+    tagInput.value = "";
+    filteredTagSuggestions.value = [];
+    showTagSuggestions.value = false;
+  };
+
+  const createAndAddSubject = async (term) => {
+    if (!term || form.value.tags.includes(term) || isCreatingSubject.value) return;
+    isCreatingSubject.value = true;
+    try {
+      const response = await vracStore.addVRACSubject(term);
+      const subjectData = response?.data || response;
+      if (subjectData?.id && subjectData?.term) {
+        allSubjects.value.push(subjectData);
+        initFuse();
+        form.value.tags.push(subjectData.term);
+      } else {
+        form.value.tags.push(term);
+      }
+      tagInput.value = "";
+      filteredTagSuggestions.value = [];
+      showTagSuggestions.value = false;
+    } catch {
+      showError("Não foi possível criar o assunto. Tente novamente.");
+    } finally {
+      isCreatingSubject.value = false;
+    }
+  };
+
+  const addTag = async () => {
+    const term = tagInput.value.trim();
+    if (!term) return;
+    if (form.value.tags.includes(term)) {
+      tagInput.value = "";
+      return;
+    }
+    const exactMatch = allSubjects.value.find(
+      (s) => s.term.toLowerCase() === term.toLowerCase()
+    );
+    if (exactMatch) {
+      selectTagSuggestion(exactMatch.term);
+    } else {
+      await createAndAddSubject(term);
+    }
+  };
+
+  const removeTag = (index) => { form.value.tags.splice(index, 1); };
+
+  // ─── Contribuidores ──────────────────────────────────────────────────────────
+  const allContributorNames = ref([]);
+
+  /**
+   * Resolve o UUID do fotógrafo a partir do nome.
+   * Cria o contribuidor na API se ainda não existir.
+   */
+  const resolvePhotographerUuid = async (metadata) => {
+    if (metadata.isAuthor) return null;
+
+    const photographerName = metadata.authorName?.trim();
+    if (!photographerName) return null;
+
+    let contributor = allContributorNames.value.find(
+      (c) => c.name.toLowerCase() === photographerName.toLowerCase()
+    );
+
+    if (!contributor) {
+      const newContributor = await vracStore.addVRACContributorName(photographerName);
+      if (newContributor?.name) {
+        contributor = newContributor.name;
+        allContributorNames.value.push(contributor);
+      }
+    }
+
+    return contributor?.id || null;
+  };
+
+  /**
+   * Converte as tags (terms) do form para seus UUIDs na API.
+   */
+  const resolveSubjectUuids = (tags = []) =>
+    tags
+      .map((tagTerm) => allSubjects.value.find((s) => s.term === tagTerm)?.id)
+      .filter(Boolean);
+
+
+  // ─── Inicialização (chamar no onMounted do componente pai) ───────────────────
+  /**
+   * Carrega subjects e contributors da API.
+   * Deve ser chamado no onMounted de quem usar o composable.
+   */
+  const loadFormDependencies = async () => {
+    const subjectsResponse = await vracStore.getVRACSubjects();
+    if (subjectsResponse?.data && Array.isArray(subjectsResponse.data)) {
+      allSubjects.value = subjectsResponse.data;
+      initFuse();
+    }
+
+    const contributorsResponse = await vracStore.getVRACContributorNames();
+    if (contributorsResponse?.names && Array.isArray(contributorsResponse.names)) {
+      allContributorNames.value = contributorsResponse.names;
+    }
+  };
+
+  /**
+   * Popula o form a partir dos dados retornados pela API (modo edição/sugestão).
+   * O mapeamento fica centralizado aqui para reusar em Edit e Suggest.
+   */
+
+  const populateFormFromApi = (data, currentUserName = null) => {
+    const authorName = data.authors?.[0] || data.rights?.[0]?.rights_holder || "";
+    const isAuthor = !!currentUserName && (
+      data.authors?.some(a => a === currentUserName) ?? false
+    );
+    const dateRaw = data.dateRaw;
+    const earliestYear = dateRaw?.earliest_date
+      ? new Date(dateRaw.earliest_date).getUTCFullYear()
+      : null;
+    const latestYear = dateRaw?.latest_date
+      ? new Date(dateRaw.latest_date).getUTCFullYear()
+      : null;
+
+    const coords =
+      Array.isArray(data.locationCoordinates) &&
+        data.locationCoordinates.length === 2 &&
+        !isNaN(data.locationCoordinates[0]) &&
+        !isNaN(data.locationCoordinates[1]) &&
+        data.locationCoordinates[0] !== 0 &&
+        data.locationCoordinates[1] !== 0
+        ? { lat: data.locationCoordinates[0], lng: data.locationCoordinates[1] }
+        : null;
+
+    form.value = {
+      ...defaultForm,
+      title: data.title || "",
+      authorName: isAuthor ? "" : authorName,
+      isAuthor,
+      isPublicDomain: false,
+      hasAuthorization: !isAuthor,
+      unknownAuthor: !authorName,
+      license: data.rights?.[0]?.text || "CC BY-NC-SA",
+      description: data.description || "",
+      tags: (data.subjects || []).map((s) => s.term || s),
+      date: earliestYear ? `${earliestYear}-01-01` : "",
+      dateEnd: latestYear ? `${latestYear}-12-31` : "",
+      dateType: earliestYear && latestYear && earliestYear !== latestYear ? "interval" : "year",
+      dateAccuracy: dateRaw?.circa ? "approximate" : "exact",
+      location: data.location || "",
+      coordinates: coords,
+    };
+  };
+
+  return {
+    // tabs
+    tabs,
+    currentSection,
+    selectTab,
+
+    // alert
+    showAlert,
+    alertMessage,
+    alertType,
+    showError,
+    showSuccess,
+
+    // identidade
+    isIdentityDropdownOpen,
+    selectedIdentityId,
+    selectedIdentity,
+    hasCollectives,
+    availableIdentities,
+    toggleIdentityDropdown,
+    selectIdentity,
+
+    // form
+    form,
+    defaultForm,
+    resetForm,
+    populateFormFromApi,
+
+    // validação
+    isTitleTouched,
+    isAuthorNameTouched,
+    isTitleInvalid,
+    isAuthorNameInvalid,
+    isRightsInvalid,
+    isEssenciaisInvalid,
+    isFormValid,
+    touchAllFields,
+
+    // datas
+    dateYearInput,
+    dateEndYearInput,
+
+    // mapa
+    mapStyleUrl,
+    mapCenter,
+    mapZoom,
+    mapInstance,
+    handleMapReady,
+    handleMapError,
+    handleMapClick,
+    zoomIn,
+    zoomOut,
+
+    // localização
+    locationSuggestions,
+    showLocationSuggestions,
+    searchLocation,
+    selectLocationSuggestion,
+    hideLocationSuggestions,
+    isSearchingLocation,
+
+    // tags
+    tagInput,
+    allSubjects,
+    filteredTagSuggestions,
+    showTagSuggestions,
+    isCreatingSubject,
+    canCreateSubject,
+    onTagInputChange,
+    hideTagSuggestions,
+    selectTagSuggestion,
+    createAndAddSubject,
+    addTag,
+    removeTag,
+
+    // contribuidores / subjects
+    allContributorNames,
+    resolvePhotographerUuid,
+    resolveSubjectUuids,
+
+    // init
+    loadFormDependencies,
+  };
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -114,6 +114,11 @@ const getImageDetails = async (id) => {
       collective,
       authors,
       date,
+      dateRaw: dateInfo ? {
+        earliest_date: dateInfo.earliest_date,
+        latest_date: dateInfo.latest_date,
+        circa: dateInfo.circa_earliest_date ?? false,
+      } : null,
       location: locationLabel,
       locationCoordinates,
       description,
@@ -211,12 +216,12 @@ const searchImages = async ({ mode, value, page = 1 } = {}) => {
 const fetchImages = async (page = 1, filters = {}) => {
   try {
     const params = { page };
-    
+
     // Filtro por busca textual geral (q)
     if (filters.q && typeof filters.q === 'string') {
       params.q = filters.q.trim();
     }
-    
+
     // Filtro por intervalo de datas
     if (filters.date_from) {
       params.date_from = filters.date_from;
@@ -224,27 +229,27 @@ const fetchImages = async (page = 1, filters = {}) => {
     if (filters.date_to) {
       params.date_to = filters.date_to;
     }
-    
+
     // Filtro por user_id
     if (filters.userId) {
       params.user_id = filters.userId;
     }
-    
+
     // Filtro por assuntos (tags de sujeito por ID)
     if (filters.subjects?.length) {
       params['subject[]'] = filters.subjects.length === 1 ? filters.subjects[0] : filters.subjects;
     }
-    
+
     // Filtro por termos de assunto (partial match)
     if (filters.subjectTerms?.length) {
       params['subject_term[]'] = filters.subjectTerms.length === 1 ? filters.subjectTerms[0] : filters.subjectTerms;
     }
-    
+
     // Filtro por título (partial match)
     if (filters.title && typeof filters.title === 'string') {
       params.title = filters.title.trim();
     }
-    
+
     // Filtro por contribuidor/autor (partial match)
     if (filters.contributor && typeof filters.contributor === 'string') {
       params.contributor = filters.contributor.trim();
@@ -257,7 +262,7 @@ const fetchImages = async (page = 1, filters = {}) => {
     if (filters.sortOrder) {
       params.sort_order = filters.sortOrder;
     }
-    
+
     const { data } = await axios.get("/api/images", { params });
 
     const rawItems = filters.excludeCollectives

--- a/src/views/ImageDetail.vue
+++ b/src/views/ImageDetail.vue
@@ -35,11 +35,10 @@
           </div>
         </div>
 
-        <ImageMetadata
-          v-if="currentSection === 'dados'"
-          :image="image"
-          :license-info="licenseInfo"
-        />
+        <ImageMetadata v-if="currentSection === 'dados' && !isEditing" :image="image" :license-info="licenseInfo" />
+
+        <ImageMetadataEdit v-else-if="currentSection === 'dados' && isEditing" :image="image"
+          @updated="fetchImageData" />
 
         <div v-else-if="currentSection === 'comentarios'">
           <div v-if="loadingComments" class="text-center py-4">
@@ -62,11 +61,13 @@
 import { ref, onMounted, computed } from "vue";
 import { RouterLink, useRoute, useRouter } from "vue-router";
 import { api } from "@/services/api";
+import { useAuthStore } from "@/store/auth";
+import { storeToRefs } from "pinia";
 import { findLicenseByUrl } from "@/constants/creativeCommonsLicenses";
 import ImageComments from "@/components/imageDetail/ImageComments.vue";
 import ImageDisplay from "@/components/imageDetail/ImageDisplay.vue";
 import ImageMetadata from "@/components/imageDetail/ImageMetadata.vue";
-
+import ImageMetadataEdit from "@/components/imageDetail/ImageMetadataEdit.vue";
 defineOptions({ name: "ImageDetail" });
 
 const router = useRouter();
@@ -75,6 +76,8 @@ const image = ref(null);
 const loading = ref(true);
 const comments = ref([]);
 const loadingComments = ref(false);
+const authStore = useAuthStore();
+const { loggedUser } = storeToRefs(authStore);
 
 const tabs = [
   {
@@ -94,6 +97,11 @@ const tabs = [
   // },
 ];
 
+const isOwner = computed(() => {
+  return loggedUser.value?.id === image.value?.uploader?.id;
+});
+
+const isEditing = computed(() => route.query.edit === "true" && isOwner.value);
 const currentSection = computed(() => route.meta?.section ?? "dados");
 
 const licenseInfo = computed(() => {
@@ -110,6 +118,15 @@ const loadComments = async (imageId) => {
     console.error("Error loading comments:", error);
   } finally {
     loadingComments.value = false;
+  }
+};
+
+const fetchImageData = async () => {
+  try {
+    const imageId = route.params.id;
+    image.value = await api.getImageDetails(imageId);
+  } catch (error) {
+    console.error("Error fetching image data:", error);
   }
 };
 


### PR DESCRIPTION
## feat: funcionalidade de edição de metadados de imagem

### Visão geral
Implementa a funcionalidade completa de edição de metadados de imagens após o upload, permitindo que o dono da imagem corrija ou atualize informações como título, descrição, autoria, data, tags e localização.

---

### Novos arquivos

**`useImageForm.js`** (composable)
Extrai toda a lógica compartilhada do formulário de metadados em um composable reutilizável. Inclui gerenciamento de estado do form, validações, tags/subjects com Fuse.js, geocoding via Nominatim, integração com mapa, resolução de UUIDs de fotógrafo e subjects, e pré-população de dados da API.

**`ImageMetadataEdit.vue`** (componente)
Novo componente de edição exclusivo para fluxo single-image com `PUT /api/images/:id`. Recebe a imagem via prop `image`, pré-popula o formulário com os dados existentes e emite evento `@updated` ao salvar com sucesso para o pai recarregar os dados.

---

### Arquivos modificados

**`api.js`**
Adicionado campo `dateRaw` no retorno de `getImageDetails` com `earliest_date`, `latest_date` e `circa` originais da API, preservando o campo `date` formatado existente para não quebrar outros consumidores.

**`ImageDetail.vue`**
Adicionada função `fetchImageData` e integração com `ImageMetadataEdit` via `@updated="fetchImageData"` para atualizar a tela sem reload. Renderização condicional entre `ImageMetadata` (visualização) e `ImageMetadataEdit` (edição) controlada por `?edit=true` na query string.

**`ImageMetadata.vue`**
Corrigida checagem de coordenadas no `mapCenter` para rejeitar `NaN` explicitamente (`isNaN(lat) || isNaN(lng)`), evitando que o mapa renderize com coordenadas inválidas após remoção de localização.

---

### Detalhes de implementação

- Payload de edição enviado como JSON via `PUT`, removendo chaves `null` exceto `latitude`, `longitude`, `location_label` e `subjects` que são enviados explicitamente para permitir apagar localização e tags
- Inferência de `isAuthor` baseada em `data.authors` comparado com o nome do usuário logado
- Datas com intervalo recuperadas via `dateRaw` e detectadas automaticamente (`dateType: "interval"` quando `earliestYear !== latestYear`)
- Mapa renderizado apenas quando há coordenadas válidas, com botão para exibir ao adicionar nova localização
- Busca de localização com loading no botão da lupa e abertura automática de sugestões ao retornar resultados
- Watch em `dateType` para sincronizar `dateEnd` ao voltar de intervalo para ano único
- Licença exibida como badge somente leitura (não editável após publicação)
- Seção de direitos de uso com mensagem inline explicativa quando imagem está em domínio público